### PR TITLE
Maintain relationship names from Prisma 1. Closes #25

### DIFF
--- a/examples/mysql-alias/expected.prisma
+++ b/examples/mysql-alias/expected.prisma
@@ -1,7 +1,7 @@
 model Category {
-  id      String    @default(cuid()) @id
-  name    String
-  Message Message[] @relation("CategoryToMessage", references: [id])
+  id       String    @default(cuid()) @id
+  name     String
+  messages Message[] @relation("CategoryToMessage", references: [id])
 }
 
 model Message {
@@ -19,10 +19,10 @@ model Message {
 }
 
 model Profile {
-  id   String  @default(cuid()) @id
-  bio  String?
-  user String? @unique
-  User User    @relation(fields: [user], references: [id])
+  id     String  @default(cuid()) @id
+  bio    String?
+  userId String? @map("user") @unique
+  user   User    @relation(fields: [user], references: [id])
   @@index([user], name: "user")
 }
 
@@ -32,8 +32,8 @@ model User {
   name     String
   role     User_role @default(CUSTOMER)
   settings Json?     @map("jsonData")
-  Message  Message[]
-  Profile  Profile?
+  messages Message[]
+  profile  Profile?
 }
 
 enum User_role {

--- a/examples/mysql-all-features-1.1/expected.prisma
+++ b/examples/mysql-all-features-1.1/expected.prisma
@@ -2,7 +2,7 @@ model Home {
   id        Int      @default(autoincrement()) @id
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  User      User[]
+  users     User[]
 }
 
 model IdentificationDocument {
@@ -10,7 +10,7 @@ model IdentificationDocument {
   documentNumber String
   issuedOn       DateTime
   expiresOn      DateTime
-  User           User
+  user           User
 }
 
 model Tagline {
@@ -38,7 +38,7 @@ model TaxDocument {
   issuedOn       DateTime
   expiresOn      DateTime
   lastChangedOn  DateTime? @updatedAt
-  User           User
+  user           User
 }
 
 model Thought {
@@ -60,34 +60,34 @@ model Thought_content {
 }
 
 model User {
-  id                               String                 @default(cuid()) @id
-  createdAt                        DateTime               @default(now())
-  updatedAt                        DateTime               @updatedAt
-  email                            String                 @unique
-  age                              Int
-  type                             User_type
-  isActive                         Boolean                @default(false)
-  temperature                      Float?
-  meta                             Json?
-  nickName                         String?                @map("friendlyName")
-  godFather                        String?
-  home                             Int?
-  taxDocument                      String?                @unique
-  identificationDocument           String?                @unique
-  bestFriend                       String?
-  tagline                          String?
-  User_UserToUser_bestFriend       User?                  @relation("UserToUser_bestFriend", fields: [bestFriend], references: [id])
-  User_UserToUser_godFather        User?                  @relation("UserToUser_godFather", fields: [godFather], references: [id])
-  Home                             Home?                  @relation(fields: [home], references: [id])
-  IdentificationDocument           IdentificationDocument @relation(fields: [identificationDocument], references: [id])
-  Tagline                          Tagline?               @relation(fields: [tagline], references: [id])
-  TaxDocument                      TaxDocument?           @relation(fields: [taxDocument], references: [id])
-  other_User_UserToUser_bestFriend User[]                 @relation("UserToUser_bestFriend")
-  other_User_UserToUser_godFather  User[]                 @relation("UserToUser_godFather")
-  Thought                          Thought[]              @relation(references: [id])
-  User_A                           User[]                 @relation("UserFriends", references: [id])
-  User_B                           User[]                 @relation("UserFriends", references: [id])
-  Work                             Work[]                 @relation(references: [id])
+  id                       String                 @default(cuid()) @id
+  createdAt                DateTime               @default(now())
+  updatedAt                DateTime               @updatedAt
+  email                    String                 @unique
+  age                      Int
+  type                     User_type
+  isActive                 Boolean                @default(false)
+  temperature              Float?
+  meta                     Json?
+  nickName                 String?                @map("friendlyName")
+  godFatherId              String?                @map("godFather")
+  homeId                   Int?                   @map("home")
+  taxDocumentId            String?                @map("taxDocument") @unique
+  identificationDocumentId String?                @map("identificationDocument") @unique
+  bestFriendId             String?                @map("bestFriend")
+  taglineId                String?                @map("tagline")
+  friendsId                User?                  @map("friends") @relation("UserToUser_bestFriend", fields: [bestFriend], references: [id])
+  friendsId                User?                  @map("friends") @relation("UserToUser_godFather", fields: [godFather], references: [id])
+  home                     Home?                  @relation(fields: [home], references: [id])
+  identificationDocument   IdentificationDocument @relation(fields: [identificationDocument], references: [id])
+  tagline                  Tagline?               @relation(fields: [tagline], references: [id])
+  taxDocument              TaxDocument?           @relation(fields: [taxDocument], references: [id])
+  friendsId                User[]                 @map("friends") @relation("UserToUser_bestFriend")
+  friendsId                User[]                 @map("friends") @relation("UserToUser_godFather")
+  thoughts                 Thought[]              @relation(references: [id])
+  friendsId                User[]                 @map("friends") @relation("UserFriends", references: [id])
+  friends                  User[]                 @relation("UserFriends", references: [id])
+  work                     Work[]                 @relation(references: [id])
   @@index([bestFriend], name: "bestFriend")
   @@index([godFather], name: "godFather")
   @@index([home], name: "home")

--- a/examples/mysql-all/expected.prisma
+++ b/examples/mysql-all/expected.prisma
@@ -1,27 +1,27 @@
 model Category {
-  id   String @default(cuid()) @id
-  name String
-  Post Post[] @relation(references: [id])
+  id    String @default(cuid()) @id
+  name  String
+  posts Post[] @relation(references: [id])
 }
 
 model Post {
-  id        String     @default(cuid()) @id
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  title     String
-  content   String?
-  published Boolean    @default(false)
-  authorId  String?
-  User      User?      @relation(fields: [authorId], references: [id])
-  Category  Category[] @relation(references: [id])
+  id         String     @default(cuid()) @id
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  title      String
+  content    String?
+  published  Boolean    @default(false)
+  authorId   String?
+  author     User?      @relation(fields: [authorId], references: [id])
+  categories Category[] @relation(references: [id])
   @@index([authorId], name: "authorId")
 }
 
 model Profile {
-  id   String  @default(cuid()) @id
-  bio  String?
-  user String? @unique
-  User User    @relation(fields: [user], references: [id])
+  id     String  @default(cuid()) @id
+  bio    String?
+  userId String? @map("user") @unique
+  user   User    @relation(fields: [user], references: [id])
   @@index([user], name: "user")
 }
 
@@ -31,8 +31,8 @@ model User {
   name     String
   role     User_role @default(CUSTOMER)
   jsonData Json?
-  Post     Post[]
-  Profile  Profile?
+  posts    Post[]
+  profile  Profile?
 }
 
 enum User_role {

--- a/examples/mysql-env/expected.prisma
+++ b/examples/mysql-env/expected.prisma
@@ -1,27 +1,27 @@
 model Category {
-  id   String @default(cuid()) @id
-  name String
-  Post Post[] @relation(references: [id])
+  id    String @default(cuid()) @id
+  name  String
+  posts Post[] @relation(references: [id])
 }
 
 model Post {
-  id        String     @default(cuid()) @id
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  title     String
-  content   String?
-  published Boolean    @default(false)
-  authorId  String?
-  User      User?      @relation(fields: [authorId], references: [id])
-  Category  Category[] @relation(references: [id])
+  id         String     @default(cuid()) @id
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  title      String
+  content    String?
+  published  Boolean    @default(false)
+  authorId   String?
+  author     User?      @relation(fields: [authorId], references: [id])
+  categories Category[] @relation(references: [id])
   @@index([authorId], name: "authorId")
 }
 
 model Profile {
-  id   String  @default(cuid()) @id
-  bio  String?
-  user String? @unique
-  User User    @relation(fields: [user], references: [id])
+  id     String  @default(cuid()) @id
+  bio    String?
+  userId String? @map("user") @unique
+  user   User    @relation(fields: [user], references: [id])
   @@index([user], name: "user")
 }
 
@@ -31,8 +31,8 @@ model User {
   name     String
   role     User_role @default(CUSTOMER)
   jsonData Json?
-  Post     Post[]
-  Profile  Profile?
+  posts    Post[]
+  profile  Profile?
 }
 
 enum User_role {

--- a/examples/mysql-has-many/expected.prisma
+++ b/examples/mysql-has-many/expected.prisma
@@ -1,11 +1,11 @@
 model Post {
-  id   String  @default(cuid()) @id
-  user String?
-  User User?   @relation(fields: [user], references: [id])
+  id     String  @default(cuid()) @id
+  userId String? @map("user")
+  user   User?   @relation(fields: [user], references: [id])
   @@index([user], name: "user")
 }
 
 model User {
-  id   String @default(cuid()) @id
-  Post Post[]
+  id    String @default(cuid()) @id
+  posts Post[]
 }

--- a/examples/mysql-many-dms/expected.prisma
+++ b/examples/mysql-many-dms/expected.prisma
@@ -1,12 +1,12 @@
 model Post {
-  id   String  @default(cuid()) @id
-  user String?
-  meta Json
-  User User?   @relation(fields: [user], references: [id])
+  id     String  @default(cuid()) @id
+  userId String? @map("user")
+  meta   Json
+  user   User?   @relation(fields: [user], references: [id])
   @@index([user], name: "user")
 }
 
 model User {
-  id   String @default(cuid()) @id
-  Post Post[]
+  id    String @default(cuid()) @id
+  posts Post[]
 }

--- a/examples/mysql-media/expected.prisma
+++ b/examples/mysql-media/expected.prisma
@@ -2,7 +2,7 @@ model Media {
   id          String  @default(cuid()) @id
   title       String?
   publisherId String
-  User        User    @relation(fields: [publisherId], references: [id])
+  publisher   User    @relation(fields: [publisherId], references: [id])
   @@index([publisherId], name: "publisherId")
 }
 
@@ -10,5 +10,5 @@ model User {
   id        String  @default(cuid()) @id
   firstName String
   lastName  String
-  Media     Media[]
+  medias    Media[]
 }

--- a/examples/mysql-required-1-to-1/expected.prisma
+++ b/examples/mysql-required-1-to-1/expected.prisma
@@ -1,13 +1,13 @@
 model Profile {
   id   String @default(cuid()) @id
   bio  String
-  User User
+  user User
 }
 
 model User {
-  id      String  @default(cuid()) @id
-  email   String  @unique
-  profile String? @unique
-  Profile Profile @relation(fields: [profile], references: [id])
+  id        String  @default(cuid()) @id
+  email     String  @unique
+  profileId String? @map("profile") @unique
+  profile   Profile @relation(fields: [profile], references: [id])
   @@index([profile], name: "profile")
 }

--- a/examples/mysql-self-relation-has-many/expected.prisma
+++ b/examples/mysql-self-relation-has-many/expected.prisma
@@ -1,7 +1,7 @@
 model User {
-  id          String  @default(cuid()) @id
-  invitedUser String?
-  User        User?   @relation("UserToUser_invitedUser", fields: [invitedUser], references: [id])
-  other_User  User[]  @relation("UserToUser_invitedUser")
+  id             String  @default(cuid()) @id
+  invitedUserId  String? @map("invitedUser")
+  invitedUsersId User?   @map("invitedUsers") @relation("UserToUser_invitedUser", fields: [invitedUser], references: [id])
+  invitedUsers   User[]  @relation("UserToUser_invitedUser")
   @@index([invitedUser], name: "invitedUser")
 }

--- a/examples/mysql-self-relation-has-one/expected.prisma
+++ b/examples/mysql-self-relation-has-one/expected.prisma
@@ -1,7 +1,7 @@
 model User {
-  id         String  @default(cuid()) @id
-  invitee    String? @unique
-  User       User    @relation("UserToUser_invitee", fields: [invitee], references: [id])
-  other_User User?   @relation("UserToUser_invitee")
+  id        String  @default(cuid()) @id
+  inviteeId String? @map("invitee") @unique
+  inviteeId User    @map("invitee") @relation("UserToUser_invitee", fields: [invitee], references: [id])
+  invitee   User?   @relation("UserToUser_invitee")
   @@index([invitee], name: "invitee")
 }

--- a/examples/mysql-self-relation-many-to-many/expected.prisma
+++ b/examples/mysql-self-relation-many-to-many/expected.prisma
@@ -1,5 +1,5 @@
 model User {
-  id     String @default(cuid()) @id
-  User_A User[] @relation("UserInvitation", references: [id])
-  User_B User[] @relation("UserInvitation", references: [id])
+  id             String @default(cuid()) @id
+  invitedUsersId User[] @map("invitedUsers") @relation("UserInvitation", references: [id])
+  invitedUsers   User[] @relation("UserInvitation", references: [id])
 }

--- a/examples/mysql-table-1-to-1/expected.prisma
+++ b/examples/mysql-table-1-to-1/expected.prisma
@@ -1,13 +1,13 @@
 model Settings {
-  id                  String  @default(cuid()) @id
-  user                String?
-  User_SettingsToUser User?   @relation(fields: [user], references: [id])
-  User_Settings       User[]  @relation("Settings", references: [id])
+  id     String  @default(cuid()) @id
+  userId String? @map("user")
+  userId User?   @map("user") @relation(fields: [user], references: [id])
+  user   User[]  @relation("Settings", references: [id])
   @@index([user], name: "user")
 }
 
 model User {
-  id                      String     @default(cuid()) @id
-  Settings_SettingsToUser Settings[]
-  Settings_Settings       Settings[] @relation("Settings", references: [id])
+  id         String     @default(cuid()) @id
+  settingsId Settings[] @map("settings")
+  settings   Settings[] @relation("Settings", references: [id])
 }

--- a/examples/mysql-table-has-many-required/expected.prisma
+++ b/examples/mysql-table-has-many-required/expected.prisma
@@ -1,11 +1,11 @@
 model Post {
   id       String @default(cuid()) @id
   authorId String
-  User     User   @relation(fields: [authorId], references: [id])
+  author   User   @relation(fields: [authorId], references: [id])
   @@index([authorId], name: "authorId")
 }
 
 model User {
-  id   String @default(cuid()) @id
-  Post Post[]
+  id    String @default(cuid()) @id
+  posts Post[]
 }

--- a/examples/mysql-table-has-many/expected.prisma
+++ b/examples/mysql-table-has-many/expected.prisma
@@ -1,11 +1,11 @@
 model Post {
   id       String  @default(cuid()) @id
   authorId String?
-  User     User?   @relation(fields: [authorId], references: [id])
+  author   User?   @relation(fields: [authorId], references: [id])
   @@index([authorId], name: "authorId")
 }
 
 model User {
-  id   String @default(cuid()) @id
-  Post Post[]
+  id    String @default(cuid()) @id
+  posts Post[]
 }

--- a/examples/mysql1-all/expected.prisma
+++ b/examples/mysql1-all/expected.prisma
@@ -3,19 +3,19 @@ model Category {
   name      String
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]   @relation(references: [id])
+  posts     Post[]   @relation(references: [id])
 }
 
 model Post {
-  id        String     @default(cuid()) @id
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  title     String
-  content   String?
-  published Boolean    @default(false)
-  authorId  String?
-  User      User?      @relation(fields: [authorId], references: [id])
-  Category  Category[] @relation(references: [id])
+  id         String     @default(cuid()) @id
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  title      String
+  content    String?
+  published  Boolean    @default(false)
+  authorId   String?
+  author     User?      @relation(fields: [authorId], references: [id])
+  categories Category[] @relation(references: [id])
   @@index([authorId], name: "authorId")
 }
 
@@ -25,7 +25,7 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String   @unique
-  User      User     @relation(fields: [userId], references: [id])
+  user      User     @relation(fields: [userId], references: [id])
 }
 
 model User {
@@ -36,8 +36,8 @@ model User {
   jsonData  Json?
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]
-  Profile   Profile?
+  posts     Post[]
+  profile   Profile?
 }
 
 enum User_role {

--- a/examples/mysql1-has-many-json/expected.prisma
+++ b/examples/mysql1-has-many-json/expected.prisma
@@ -3,7 +3,7 @@ model Post {
   updatedAt DateTime
   createdAt DateTime
   authorId  String
-  User      User     @relation(fields: [authorId], references: [id])
+  author    User     @relation(fields: [authorId], references: [id])
   @@index([authorId], name: "authorId")
 }
 
@@ -12,5 +12,5 @@ model User {
   meta      Json?
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]
+  posts     Post[]
 }

--- a/examples/mysql1-has-many/expected.prisma
+++ b/examples/mysql1-has-many/expected.prisma
@@ -3,7 +3,7 @@ model Post {
   updatedAt DateTime
   createdAt DateTime
   authorId  String
-  User      User     @relation(fields: [authorId], references: [id])
+  author    User     @relation(fields: [authorId], references: [id])
   @@index([authorId], name: "authorId")
 }
 
@@ -11,5 +11,5 @@ model User {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]
+  posts     Post[]
 }

--- a/examples/mysql1-has-many2/expected.prisma
+++ b/examples/mysql1-has-many2/expected.prisma
@@ -2,7 +2,7 @@ model AUser {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]
+  posts     Post[]
 }
 
 model Post {
@@ -10,6 +10,6 @@ model Post {
   updatedAt DateTime
   createdAt DateTime
   authorId  String
-  AUser     AUser    @relation(fields: [authorId], references: [id])
+  author    AUser    @relation(fields: [authorId], references: [id])
   @@index([authorId], name: "authorId")
 }

--- a/examples/mysql1-has-one-36/expected.prisma
+++ b/examples/mysql1-has-one-36/expected.prisma
@@ -1,9 +1,9 @@
 model Companie {
-  id               String             @default(cuid()) @id
-  companieRole     String
-  updatedAt        DateTime
-  createdAt        DateTime
-  UserRoleCompanie UserRoleCompanie[]
+  id                String             @default(cuid()) @id
+  companieRole      String
+  updatedAt         DateTime
+  createdAt         DateTime
+  userRoleCompanies UserRoleCompanie[]
 }
 
 model IssuedCard {
@@ -12,16 +12,16 @@ model IssuedCard {
   updatedAt DateTime
   createdAt DateTime
   userId    String
-  User      User     @relation(fields: [userId], references: [id])
+  user      User     @relation(fields: [userId], references: [id])
   @@index([userId], name: "userId")
 }
 
 model User {
-  id         String       @default(cuid()) @id
-  firstName  String
-  updatedAt  DateTime
-  createdAt  DateTime
-  IssuedCard IssuedCard[]
+  id          String       @default(cuid()) @id
+  firstName   String
+  updatedAt   DateTime
+  createdAt   DateTime
+  issuedCards IssuedCard[]
 }
 
 model UserRoleCompanie {
@@ -29,6 +29,6 @@ model UserRoleCompanie {
   updatedAt  DateTime
   createdAt  DateTime
   companieId String
-  Companie   Companie @relation(fields: [companieId], references: [id])
+  companie   Companie @relation(fields: [companieId], references: [id])
   @@index([companieId], name: "companieId")
 }

--- a/examples/mysql1-has-one-optional/expected.prisma
+++ b/examples/mysql1-has-one-optional/expected.prisma
@@ -3,12 +3,12 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String?  @unique
-  User      User?    @relation(fields: [userId], references: [id])
+  author    User?    @relation(fields: [userId], references: [id])
 }
 
 model User {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Profile   Profile
+  profile   Profile
 }

--- a/examples/mysql1-has-one-optional2/expected.prisma
+++ b/examples/mysql1-has-one-optional2/expected.prisma
@@ -3,12 +3,12 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String   @unique
-  User      User     @relation(fields: [userId], references: [id])
+  author    User     @relation(fields: [userId], references: [id])
 }
 
 model User {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Profile   Profile?
+  profile   Profile?
 }

--- a/examples/mysql1-has-one/expected.prisma
+++ b/examples/mysql1-has-one/expected.prisma
@@ -3,12 +3,12 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String   @unique
-  User      User     @relation(fields: [userId], references: [id])
+  author    User     @relation(fields: [userId], references: [id])
 }
 
 model User {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Profile   Profile
+  profile   Profile
 }

--- a/examples/mysql1-many-to-many/expected.prisma
+++ b/examples/mysql1-many-to-many/expected.prisma
@@ -2,12 +2,12 @@ model Post {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Tag       Tag[]    @relation(references: [id])
+  tags      Tag[]    @relation(references: [id])
 }
 
 model Tag {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]   @relation(references: [id])
+  posts     Post[]   @relation(references: [id])
 }

--- a/examples/mysql1-self-relation-has-many/expected.prisma
+++ b/examples/mysql1-self-relation-has-many/expected.prisma
@@ -1,9 +1,9 @@
 model User {
-  id            String   @default(cuid()) @id
-  updatedAt     DateTime
-  createdAt     DateTime
-  invitedUserId String
-  User          User     @relation("UserToUser_invitedUserId", fields: [invitedUserId], references: [id])
-  other_User    User[]   @relation("UserToUser_invitedUserId")
+  id             String   @default(cuid()) @id
+  updatedAt      DateTime
+  createdAt      DateTime
+  invitedUserId  String
+  invitedUsersId User     @map("invitedUsers") @relation("UserToUser_invitedUserId", fields: [invitedUserId], references: [id])
+  invitedUsers   User[]   @relation("UserToUser_invitedUserId")
   @@index([invitedUserId], name: "invitedUserId")
 }

--- a/examples/mysql1-self-relation-has-one/expected.prisma
+++ b/examples/mysql1-self-relation-has-one/expected.prisma
@@ -1,8 +1,8 @@
 model User {
-  id         String   @default(cuid()) @id
-  updatedAt  DateTime
-  createdAt  DateTime
-  userId     String?  @unique
-  User       User?    @relation("UserToUser_userId", fields: [userId], references: [id])
-  other_User User?    @relation("UserToUser_userId")
+  id        String   @default(cuid()) @id
+  updatedAt DateTime
+  createdAt DateTime
+  userId    String?  @unique
+  inviterId User?    @map("inviter") @relation("UserToUser_userId", fields: [userId], references: [id])
+  inviter   User?    @relation("UserToUser_userId")
 }

--- a/examples/mysql1-self-relation-many-to-many/expected.prisma
+++ b/examples/mysql1-self-relation-many-to-many/expected.prisma
@@ -1,7 +1,7 @@
 model User {
-  id        String   @default(cuid()) @id
-  updatedAt DateTime
-  createdAt DateTime
-  User_A    User[]   @relation("UserInvitation", references: [id])
-  User_B    User[]   @relation("UserInvitation", references: [id])
+  id             String   @default(cuid()) @id
+  updatedAt      DateTime
+  createdAt      DateTime
+  invitedUsersId User[]   @map("invitedUsers") @relation("UserInvitation", references: [id])
+  invitedUsers   User[]   @relation("UserInvitation", references: [id])
 }

--- a/examples/postgres-alias/expected.prisma
+++ b/examples/postgres-alias/expected.prisma
@@ -1,7 +1,7 @@
 model Category {
-  id      String    @default(cuid()) @id
-  name    String
-  Message Message[] @relation("CategoryToMessage", references: [id])
+  id       String    @default(cuid()) @id
+  name     String
+  messages Message[] @relation("CategoryToMessage", references: [id])
 }
 
 model Message {
@@ -18,20 +18,20 @@ model Message {
 }
 
 model Profile {
-  id   String  @default(cuid()) @id
-  bio  String?
-  user String? @unique
-  User User    @relation(fields: [user], references: [id])
+  id     String  @default(cuid()) @id
+  bio    String?
+  userId String? @map("user") @unique
+  user   User    @relation(fields: [user], references: [id])
 }
 
 model User {
   id       String    @default(cuid()) @id
   email    String?   @unique
   name     String
-  role     Role      @default(CUSTOMER)
+  role     Role      @default(CUSTOMER) @map("role")
   settings Json?     @map("jsonData")
-  Message  Message[]
-  Profile  Profile?
+  messages Message[]
+  profile  Profile?
 }
 
 enum Role {

--- a/examples/postgres-all-features-1.1/expected.prisma
+++ b/examples/postgres-all-features-1.1/expected.prisma
@@ -2,7 +2,7 @@ model Home {
   id        Int      @default(autoincrement()) @id
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  User      User[]
+  users     User[]
 }
 
 model IdentificationDocument {
@@ -10,7 +10,7 @@ model IdentificationDocument {
   documentNumber String
   issuedOn       DateTime
   expiresOn      DateTime
-  User           User
+  user           User
 }
 
 model Tagline {
@@ -19,7 +19,7 @@ model Tagline {
   updatedAt   DateTime            @updatedAt
   description String?
   excerpt     String
-  visibility  TaglineVisibility[]
+  visibility  TaglineVisibility[] @map("visibility")
   User        User[]
 }
 
@@ -29,7 +29,7 @@ model TaxDocument {
   issuedOn       DateTime
   expiresOn      DateTime
   lastChangedOn  DateTime? @updatedAt
-  User           User
+  user           User
 }
 
 model Thought {
@@ -42,34 +42,34 @@ model Thought {
 }
 
 model User {
-  id                               String                 @default(cuid()) @id
-  createdAt                        DateTime               @default(now())
-  updatedAt                        DateTime               @updatedAt
-  email                            String                 @unique
-  age                              Int
-  type                             UserType
-  isActive                         Boolean                @default(false)
-  temperature                      Float?
-  meta                             Json?
-  nickName                         String?                @map("friendlyName")
-  godFather                        String?
-  home                             Int?
-  taxDocument                      String?                @unique
-  identificationDocument           String?                @unique
-  bestFriend                       String?
-  tagline                          String?
-  User_UserToUser_bestFriend       User?                  @relation("UserToUser_bestFriend", fields: [bestFriend], references: [id])
-  User_UserToUser_godFather        User?                  @relation("UserToUser_godFather", fields: [godFather], references: [id])
-  Home                             Home?                  @relation(fields: [home], references: [id])
-  IdentificationDocument           IdentificationDocument @relation(fields: [identificationDocument], references: [id])
-  Tagline                          Tagline?               @relation(fields: [tagline], references: [id])
-  TaxDocument                      TaxDocument?           @relation(fields: [taxDocument], references: [id])
-  other_User_UserToUser_bestFriend User[]                 @relation("UserToUser_bestFriend")
-  other_User_UserToUser_godFather  User[]                 @relation("UserToUser_godFather")
-  Thought                          Thought[]              @relation(references: [id])
-  User_A                           User[]                 @relation("UserFriends", references: [id])
-  User_B                           User[]                 @relation("UserFriends", references: [id])
-  Work                             Work[]                 @relation(references: [id])
+  id                       String                 @default(cuid()) @id
+  createdAt                DateTime               @default(now())
+  updatedAt                DateTime               @updatedAt
+  email                    String                 @unique
+  age                      Int
+  type                     UserType               @map("type")
+  isActive                 Boolean                @default(false)
+  temperature              Float?
+  meta                     Json?
+  nickName                 String?                @map("friendlyName")
+  godFatherId              String?                @map("godFather")
+  homeId                   Int?                   @map("home")
+  taxDocumentId            String?                @map("taxDocument") @unique
+  identificationDocumentId String?                @map("identificationDocument") @unique
+  bestFriendId             String?                @map("bestFriend")
+  taglineId                String?                @map("tagline")
+  friendsId                User?                  @map("friends") @relation("UserToUser_bestFriend", fields: [bestFriend], references: [id])
+  friendsId                User?                  @map("friends") @relation("UserToUser_godFather", fields: [godFather], references: [id])
+  home                     Home?                  @relation(fields: [home], references: [id])
+  identificationDocument   IdentificationDocument @relation(fields: [identificationDocument], references: [id])
+  tagline                  Tagline?               @relation(fields: [tagline], references: [id])
+  taxDocument              TaxDocument?           @relation(fields: [taxDocument], references: [id])
+  friendsId                User[]                 @map("friends") @relation("UserToUser_bestFriend")
+  friendsId                User[]                 @map("friends") @relation("UserToUser_godFather")
+  thoughts                 Thought[]              @relation(references: [id])
+  friendsId                User[]                 @map("friends") @relation("UserFriends", references: [id])
+  friends                  User[]                 @relation("UserFriends", references: [id])
+  work                     Work[]                 @relation(references: [id])
 }
 
 model Work {

--- a/examples/postgres-all/expected.prisma
+++ b/examples/postgres-all/expected.prisma
@@ -1,36 +1,36 @@
 model Category {
-  id   String @default(cuid()) @id
-  name String
-  Post Post[] @relation(references: [id])
+  id    String @default(cuid()) @id
+  name  String
+  posts Post[] @relation(references: [id])
 }
 
 model Post {
-  id        String     @default(cuid()) @id
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  title     String
-  content   String?
-  published Boolean    @default(false)
-  authorId  String?
-  User      User?      @relation(fields: [authorId], references: [id])
-  Category  Category[] @relation(references: [id])
+  id         String     @default(cuid()) @id
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  title      String
+  content    String?
+  published  Boolean    @default(false)
+  authorId   String?
+  author     User?      @relation(fields: [authorId], references: [id])
+  categories Category[] @relation(references: [id])
 }
 
 model Profile {
-  id   String  @default(cuid()) @id
-  bio  String?
-  user String? @unique
-  User User    @relation(fields: [user], references: [id])
+  id     String  @default(cuid()) @id
+  bio    String?
+  userId String? @map("user") @unique
+  user   User    @relation(fields: [user], references: [id])
 }
 
 model User {
   id       String   @default(cuid()) @id
   email    String?  @unique
   name     String
-  role     Role     @default(CUSTOMER)
+  role     Role     @default(CUSTOMER) @map("role")
   jsonData Json?
-  Post     Post[]
-  Profile  Profile?
+  posts    Post[]
+  profile  Profile?
 }
 
 enum Role {

--- a/examples/postgres-default-enum/expected.prisma
+++ b/examples/postgres-default-enum/expected.prisma
@@ -1,6 +1,6 @@
 model User {
   id   String @default(cuid()) @id
-  role Role   @default(CUSTOMER)
+  role Role   @default(CUSTOMER) @map("role")
 }
 
 enum Role {

--- a/examples/postgres-env/expected.prisma
+++ b/examples/postgres-env/expected.prisma
@@ -1,36 +1,36 @@
 model Category {
-  id   String @default(cuid()) @id
-  name String
-  Post Post[] @relation(references: [id])
+  id    String @default(cuid()) @id
+  name  String
+  posts Post[] @relation(references: [id])
 }
 
 model Post {
-  id        String     @default(cuid()) @id
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  title     String
-  content   String?
-  published Boolean    @default(false)
-  authorId  String?
-  User      User?      @relation(fields: [authorId], references: [id])
-  Category  Category[] @relation(references: [id])
+  id         String     @default(cuid()) @id
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  title      String
+  content    String?
+  published  Boolean    @default(false)
+  authorId   String?
+  author     User?      @relation(fields: [authorId], references: [id])
+  categories Category[] @relation(references: [id])
 }
 
 model Profile {
-  id   String  @default(cuid()) @id
-  bio  String?
-  user String? @unique
-  User User    @relation(fields: [user], references: [id])
+  id     String  @default(cuid()) @id
+  bio    String?
+  userId String? @map("user") @unique
+  user   User    @relation(fields: [user], references: [id])
 }
 
 model User {
   id       String   @default(cuid()) @id
   email    String?  @unique
   name     String
-  role     Role     @default(CUSTOMER)
+  role     Role     @default(CUSTOMER) @map("role")
   jsonData Json?
-  Post     Post[]
-  Profile  Profile?
+  posts    Post[]
+  profile  Profile?
 }
 
 enum Role {

--- a/examples/postgres-has-many/expected.prisma
+++ b/examples/postgres-has-many/expected.prisma
@@ -1,10 +1,10 @@
 model PostModel {
-  id        String    @default(cuid()) @id
-  user      String
-  UserModel UserModel @relation(fields: [user], references: [id])
+  id     String    @default(cuid()) @id
+  userId String    @map("user")
+  user   UserModel @relation(fields: [user], references: [id])
 }
 
 model UserModel {
-  id        String      @default(cuid()) @id
-  PostModel PostModel[]
+  id    String      @default(cuid()) @id
+  posts PostModel[]
 }

--- a/examples/postgres-media/expected.prisma
+++ b/examples/postgres-media/expected.prisma
@@ -2,19 +2,19 @@ model Media {
   id          String  @default(cuid()) @id
   title       String?
   publisherId String
-  User        User    @relation(fields: [publisherId], references: [id])
+  publisher   User    @relation(fields: [publisherId], references: [id])
 }
 
 model User {
   id        String  @default(cuid()) @id
   firstName String
   lastName  String
-  Media     Media[]
-  WebTV     WebTV[]
+  medias    Media[]
+  webTVs    WebTV[]
 }
 
 model WebTV {
   id          String @default(cuid()) @id
   publisherId String
-  User        User   @relation(fields: [publisherId], references: [id])
+  publisher   User   @relation(fields: [publisherId], references: [id])
 }

--- a/examples/postgres-required-1-to-1/expected.prisma
+++ b/examples/postgres-required-1-to-1/expected.prisma
@@ -1,12 +1,12 @@
 model Profile {
   id   String @default(cuid()) @id
   bio  String
-  User User
+  user User
 }
 
 model User {
-  id      String  @default(cuid()) @id
-  email   String  @unique
-  profile String? @unique
-  Profile Profile @relation(fields: [profile], references: [id])
+  id        String  @default(cuid()) @id
+  email     String  @unique
+  profileId String? @map("profile") @unique
+  profile   Profile @relation(fields: [profile], references: [id])
 }

--- a/examples/postgres-scalar-list-enum/expected.prisma
+++ b/examples/postgres-scalar-list-enum/expected.prisma
@@ -1,6 +1,6 @@
 model User {
   id    String @default(cuid()) @id
-  roles Role[]
+  roles Role[] @map("roles")
 }
 
 enum Role {

--- a/examples/postgres-scalar-lists/expected.prisma
+++ b/examples/postgres-scalar-lists/expected.prisma
@@ -1,7 +1,7 @@
 model User {
   id        String    @default(cuid()) @id
   coinflips Boolean[]
-  roles     Role[]
+  roles     Role[]    @map("roles")
   names     String[]
 }
 

--- a/examples/postgres-self-relation-has-many/expected.prisma
+++ b/examples/postgres-self-relation-has-many/expected.prisma
@@ -1,6 +1,6 @@
 model User {
-  id          String  @default(cuid()) @id
-  invitedUser String?
-  User        User?   @relation("UserToUser_invitedUser", fields: [invitedUser], references: [id])
-  other_User  User[]  @relation("UserToUser_invitedUser")
+  id             String  @default(cuid()) @id
+  invitedUserId  String? @map("invitedUser")
+  invitedUsersId User?   @map("invitedUsers") @relation("UserToUser_invitedUser", fields: [invitedUser], references: [id])
+  invitedUsers   User[]  @relation("UserToUser_invitedUser")
 }

--- a/examples/postgres-self-relation-has-one/expected.prisma
+++ b/examples/postgres-self-relation-has-one/expected.prisma
@@ -1,6 +1,6 @@
 model User {
-  id         String  @default(cuid()) @id
-  invitee    String? @unique
-  User       User    @relation("UserToUser_invitee", fields: [invitee], references: [id])
-  other_User User?   @relation("UserToUser_invitee")
+  id        String  @default(cuid()) @id
+  inviteeId String? @map("invitee") @unique
+  inviteeId User    @map("invitee") @relation("UserToUser_invitee", fields: [invitee], references: [id])
+  invitee   User?   @relation("UserToUser_invitee")
 }

--- a/examples/postgres-self-relation-many-to-many/expected.prisma
+++ b/examples/postgres-self-relation-many-to-many/expected.prisma
@@ -1,6 +1,6 @@
 model User {
-  id          String  @default(cuid()) @id
-  invitedUser String?
-  User        User?   @relation("UserToUser_invitedUser", fields: [invitedUser], references: [id])
-  other_User  User[]  @relation("UserToUser_invitedUser")
+  id             String  @default(cuid()) @id
+  invitedUser    String?
+  invitedUsersId User?   @map("invitedUsers") @relation("UserToUser_invitedUser", fields: [invitedUser], references: [id])
+  invitedUsers   User[]  @relation("UserToUser_invitedUser")
 }

--- a/examples/postgres-table-1-to-1/expected.prisma
+++ b/examples/postgres-table-1-to-1/expected.prisma
@@ -1,12 +1,12 @@
 model Settings {
-  id                  String  @default(cuid()) @id
-  user                String?
-  User_SettingsToUser User?   @relation(fields: [user], references: [id])
-  User_Settings       User[]  @relation("Settings", references: [id])
+  id     String  @default(cuid()) @id
+  userId String? @map("user")
+  userId User?   @map("user") @relation(fields: [user], references: [id])
+  user   User[]  @relation("Settings", references: [id])
 }
 
 model User {
-  id                      String     @default(cuid()) @id
-  Settings_SettingsToUser Settings[]
-  Settings_Settings       Settings[] @relation("Settings", references: [id])
+  id         String     @default(cuid()) @id
+  settingsId Settings[] @map("settings")
+  settings   Settings[] @relation("Settings", references: [id])
 }

--- a/examples/postgres-table-has-many-required/expected.prisma
+++ b/examples/postgres-table-has-many-required/expected.prisma
@@ -1,10 +1,10 @@
 model Post {
   id       String @default(cuid()) @id
   authorId String
-  User     User   @relation(fields: [authorId], references: [id])
+  author   User   @relation(fields: [authorId], references: [id])
 }
 
 model User {
-  id   String @default(cuid()) @id
-  Post Post[]
+  id    String @default(cuid()) @id
+  posts Post[]
 }

--- a/examples/postgres-table-has-many/expected.prisma
+++ b/examples/postgres-table-has-many/expected.prisma
@@ -1,10 +1,10 @@
 model Post {
   id       String  @default(cuid()) @id
   authorId String?
-  User     User?   @relation(fields: [authorId], references: [id])
+  author   User?   @relation(fields: [authorId], references: [id])
 }
 
 model User {
-  id   String @default(cuid()) @id
-  Post Post[]
+  id    String @default(cuid()) @id
+  posts Post[]
 }

--- a/examples/postgres1-all/expected.prisma
+++ b/examples/postgres1-all/expected.prisma
@@ -3,19 +3,19 @@ model Category {
   name      String
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]   @relation(references: [id])
+  posts     Post[]   @relation(references: [id])
 }
 
 model Post {
-  id        String     @default(cuid()) @id
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  title     String
-  content   String?
-  published Boolean    @default(false)
-  authorId  String?
-  User      User?      @relation(fields: [authorId], references: [id])
-  Category  Category[] @relation(references: [id])
+  id         String     @default(cuid()) @id
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  title      String
+  content    String?
+  published  Boolean    @default(false)
+  authorId   String?
+  author     User?      @relation(fields: [authorId], references: [id])
+  categories Category[] @relation(references: [id])
 }
 
 model Profile {
@@ -24,19 +24,19 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String   @unique
-  User      User     @relation(fields: [userId], references: [id])
+  user      User     @relation(fields: [userId], references: [id])
 }
 
 model User {
   id        String   @default(cuid()) @id
   email     String?  @unique
   name      String
-  role      Role     @default(CUSTOMER)
+  role      Role     @default(CUSTOMER) @map("role")
   jsonData  Json?
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]
-  Profile   Profile?
+  posts     Post[]
+  profile   Profile?
 }
 
 enum Role {

--- a/examples/postgres1-has-many/expected.prisma
+++ b/examples/postgres1-has-many/expected.prisma
@@ -3,12 +3,12 @@ model Post {
   updatedAt DateTime
   createdAt DateTime
   authorId  String
-  User      User     @relation(fields: [authorId], references: [id])
+  author    User     @relation(fields: [authorId], references: [id])
 }
 
 model User {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]
+  posts     Post[]
 }

--- a/examples/postgres1-has-many2/expected.prisma
+++ b/examples/postgres1-has-many2/expected.prisma
@@ -2,7 +2,7 @@ model AUser {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]
+  posts     Post[]
 }
 
 model Post {
@@ -10,5 +10,5 @@ model Post {
   updatedAt DateTime
   createdAt DateTime
   authorId  String
-  AUser     AUser    @relation(fields: [authorId], references: [id])
+  author    AUser    @relation(fields: [authorId], references: [id])
 }

--- a/examples/postgres1-has-one-json/expected.prisma
+++ b/examples/postgres1-has-one-json/expected.prisma
@@ -3,7 +3,7 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String   @unique
-  User      User     @relation(fields: [userId], references: [id])
+  author    User     @relation(fields: [userId], references: [id])
 }
 
 model User {
@@ -11,5 +11,5 @@ model User {
   meta      Json
   updatedAt DateTime
   createdAt DateTime
-  Profile   Profile
+  profile   Profile
 }

--- a/examples/postgres1-has-one-optional/expected.prisma
+++ b/examples/postgres1-has-one-optional/expected.prisma
@@ -3,12 +3,12 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String?  @unique
-  User      User?    @relation(fields: [userId], references: [id])
+  author    User?    @relation(fields: [userId], references: [id])
 }
 
 model User {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Profile   Profile
+  profile   Profile
 }

--- a/examples/postgres1-has-one-optional2/expected.prisma
+++ b/examples/postgres1-has-one-optional2/expected.prisma
@@ -3,12 +3,12 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String   @unique
-  User      User     @relation(fields: [userId], references: [id])
+  author    User     @relation(fields: [userId], references: [id])
 }
 
 model User {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Profile   Profile?
+  profile   Profile?
 }

--- a/examples/postgres1-has-one/expected.prisma
+++ b/examples/postgres1-has-one/expected.prisma
@@ -3,12 +3,12 @@ model Profile {
   updatedAt DateTime
   createdAt DateTime
   userId    String   @unique
-  User      User     @relation(fields: [userId], references: [id])
+  author    User     @relation(fields: [userId], references: [id])
 }
 
 model User {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Profile   Profile
+  profile   Profile
 }

--- a/examples/postgres1-many-to-many/expected.prisma
+++ b/examples/postgres1-many-to-many/expected.prisma
@@ -2,12 +2,12 @@ model Post {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Tag       Tag[]    @relation(references: [id])
+  tags      Tag[]    @relation(references: [id])
 }
 
 model Tag {
   id        String   @default(cuid()) @id
   updatedAt DateTime
   createdAt DateTime
-  Post      Post[]   @relation(references: [id])
+  posts     Post[]   @relation(references: [id])
 }

--- a/examples/postgres1-scalar-lists/expected.prisma
+++ b/examples/postgres1-scalar-lists/expected.prisma
@@ -3,7 +3,7 @@ model User {
   updatedAt DateTime
   createdAt DateTime
   coinflips Boolean[]
-  roles     Role[]
+  roles     Role[]    @map("roles")
 }
 
 enum Role {

--- a/examples/postgres1-self-relation-has-many/expected.prisma
+++ b/examples/postgres1-self-relation-has-many/expected.prisma
@@ -1,8 +1,8 @@
 model User {
-  id            String   @default(cuid()) @id
-  updatedAt     DateTime
-  createdAt     DateTime
-  invitedUserId String
-  User          User     @relation("UserToUser_invitedUserId", fields: [invitedUserId], references: [id])
-  other_User    User[]   @relation("UserToUser_invitedUserId")
+  id             String   @default(cuid()) @id
+  updatedAt      DateTime
+  createdAt      DateTime
+  invitedUserId  String
+  invitedUsersId User     @map("invitedUsers") @relation("UserToUser_invitedUserId", fields: [invitedUserId], references: [id])
+  invitedUsers   User[]   @relation("UserToUser_invitedUserId")
 }

--- a/examples/postgres1-self-relation-has-one/expected.prisma
+++ b/examples/postgres1-self-relation-has-one/expected.prisma
@@ -1,8 +1,8 @@
 model User {
-  id         String   @default(cuid()) @id
-  updatedAt  DateTime
-  createdAt  DateTime
-  userId     String   @unique
-  User       User     @relation("UserToUser_userId", fields: [userId], references: [id])
-  other_User User?    @relation("UserToUser_userId")
+  id        String   @default(cuid()) @id
+  updatedAt DateTime
+  createdAt DateTime
+  userId    String   @unique
+  inviteeId User     @map("invitee") @relation("UserToUser_userId", fields: [userId], references: [id])
+  invitee   User?    @relation("UserToUser_userId")
 }

--- a/examples/postgres1-self-relation-many-to-many/expected.prisma
+++ b/examples/postgres1-self-relation-many-to-many/expected.prisma
@@ -1,7 +1,7 @@
 model User {
-  id        String   @default(cuid()) @id
-  updatedAt DateTime
-  createdAt DateTime
-  User_A    User[]   @relation("UserInvitation", references: [id])
-  User_B    User[]   @relation("UserInvitation", references: [id])
+  id             String   @default(cuid()) @id
+  updatedAt      DateTime
+  createdAt      DateTime
+  invitedUsersId User[]   @map("invitedUsers") @relation("UserInvitation", references: [id])
+  invitedUsers   User[]   @relation("UserInvitation", references: [id])
 }

--- a/examples/postgres1-self-relation/expected.prisma
+++ b/examples/postgres1-self-relation/expected.prisma
@@ -3,6 +3,6 @@ model User {
   updatedAt   DateTime
   createdAt   DateTime
   invitedById String?
-  User        User?    @relation("UserToUser_invitedById", fields: [invitedById], references: [id])
-  other_User  User[]   @relation("UserToUser_invitedById")
+  invitedById User?    @map("invitedBy") @relation("UserToUser_invitedById", fields: [invitedById], references: [id])
+  invitedBy   User[]   @relation("UserToUser_invitedById")
 }

--- a/src/api/index_test.ts
+++ b/src/api/index_test.ts
@@ -327,7 +327,7 @@ async function test(
 
   // schema
   const actual = schema.toTestString()
-  // fs.writeFileSync(path.join(_abspath, 'expected.prisma'), actual)
+  // fs.writeFileSync(path.join(_abspath, "expected.prisma"), actual)
   if (expected.trim() !== actual) {
     console.log("")
     console.log("Actual:")

--- a/src/prisma2/index.ts
+++ b/src/prisma2/index.ts
@@ -413,6 +413,18 @@ export class Field {
     this.n.datatype = datatype
   }
 
+  get dbname(): string {
+    const map = this.attributes.find((a) => a.name === "map")
+    if (!map) {
+      return this.n.name.name
+    }
+    const arg = map.arguments[0]
+    if (!arg || arg.value.type !== "string_value") {
+      return this.n.name.name
+    }
+    return arg.value.value
+  }
+
   rename(name: string): void {
     const dbName = this.name
     this.setName(name)
@@ -524,6 +536,24 @@ export class DataType {
         return new DataType(this.n.inner)
       default:
         return this
+    }
+  }
+
+  isReference(): boolean {
+    const innermost = this.innermost()
+    const n = innermost.n
+    if (n.type !== "named_type") {
+      return false
+    }
+    switch (n.name.name) {
+      case "String":
+      case "Float":
+      case "Int":
+      case "DateTime":
+      case "Json":
+        return false
+      default:
+        return true
     }
   }
 

--- a/src/sql/index.ts
+++ b/src/sql/index.ts
@@ -305,7 +305,7 @@ export class Postgres implements Translator {
     const stmts: string[] = []
     for (let pair of op.pairs) {
       const modelName = this.schema(op.schema, pair.model.dbname)
-      const fieldName = pair.field.name
+      const fieldName = pair.field.dbname
       stmts.push(`ALTER TABLE ${modelName} ALTER COLUMN "${fieldName}" SET DATA TYPE character varying(30);`)
     }
     return stmts.join("\n")
@@ -566,7 +566,7 @@ export class MySQL5 implements Translator {
     stmts.push(`SET FOREIGN_KEY_CHECKS=0;`)
     for (let pair of op.pairs) {
       const modelName = this.backtick(pair.model.dbname)
-      const fieldName = this.backtick(pair.field.name)
+      const fieldName = this.backtick(pair.field.dbname)
       const notNull = pair.field.type.optional() ? "" : "NOT NULL"
       stmts.push(`ALTER TABLE ${modelName} CHANGE ${fieldName} ${fieldName} char(30) CHARACTER SET utf8 ${notNull};`)
     }


### PR DESCRIPTION
This PR aims to maintain the relation names from P1 schemas.

**Note** This is a 95% solution. It doesn't cover the following cases where there are multiple fields pointing back to the same model. 

```graphql
type User {
    bestFriend: User @relation(name: "UserBestFriend") # Optional self 1-1 relation
    godFather: User! @relation(name: "UserGodFather") # Required self 1-1 relation
    friends: [User!] @relation(name: "UserFriends", onDelete: CASCADE) # Self 1-m relation, cascade
}
```

In this case, you'll end up with duplicate field names

```prisma
model User {
  friendsId                User?                  @map("friends") @relation("UserToUser_bestFriend", fields: [bestFriend], references: [id])
  friendsId                User[]                 @map("friends") @relation("UserToUser_godFather")
}
```

We **do not plan** on fixing this, since it's a difficult problem. We recommend you install the [Prisma Language Tools](https://github.com/prisma/language-tools) for your IDE to detect these cases, then rename them manually.