### PR TITLE
Make cuid columns 30 characters wide

### DIFF
--- a/src/sql/index.ts
+++ b/src/sql/index.ts
@@ -250,7 +250,7 @@ export class Postgres implements Translator {
     const notNull = op.p1FieldOne.optional() ? "" : "NOT NULL"
     const columnNameOneIDLetter = modelNameMany > modelNameOne ? "A" : "B"
     const foreignNameLetter = modelNameMany < modelNameOne ? "A" : "B"
-    stmts.push(`ALTER TABLE ${tableNameOne} ADD COLUMN "${foreignName}" CHARACTER VARYING(25);`)
+    stmts.push(`ALTER TABLE ${tableNameOne} ADD COLUMN "${foreignName}" CHARACTER VARYING(30);`)
     stmts.push(
       `UPDATE ${tableNameOne} SET "${foreignName}" = ${joinTableName}."${foreignNameLetter}" FROM ${joinTableName} WHERE ${joinTableName}."${columnNameOneIDLetter}" = ${tableNameOne}."${columnNameOneID}";`
     )
@@ -277,7 +277,7 @@ export class Postgres implements Translator {
     const notNull = op.p1FieldOne.optional() ? "" : "NOT NULL"
     const columnNameOneIDLetter = modelNameOther > modelNameOne ? "A" : "B"
     const foreignNameLetter = modelNameOther < modelNameOne ? "A" : "B"
-    stmts.push(`ALTER TABLE ${tableNameOne} ADD COLUMN "${foreignName}" CHARACTER VARYING(25) unique;`)
+    stmts.push(`ALTER TABLE ${tableNameOne} ADD COLUMN "${foreignName}" CHARACTER VARYING(30) unique;`)
     stmts.push(
       `UPDATE ${tableNameOne} SET "${foreignName}" = ${joinTableName}."${foreignNameLetter}" FROM ${joinTableName} WHERE ${joinTableName}."${columnNameOneIDLetter}" = ${tableNameOne}."${columnNameOneID}";`
     )


### PR DESCRIPTION
Missed some spots from setting id columns to 30 characters. (https://github.com/prisma/prisma-engines/issues/878)

We learned this the hard way (production db) and it was quite hard to debug since the error message we got was `Error: The provided value for the column is too long for the column's type. Column: <unknown>`. 

The column was actually one of a join table for a many-to-many relation. 

