### PR TITLE
fix(MigrateOneToOneTableOp): Activate forgotten (?) statement

### DIFF
--- a/src/sql/index.ts
+++ b/src/sql/index.ts
@@ -250,6 +250,7 @@ export class Postgres implements Translator {
     const notNull = op.p1FieldOne.optional() ? "" : "NOT NULL"
     const columnNameOneIDLetter = modelNameMany > modelNameOne ? "A" : "B"
     const foreignNameLetter = modelNameMany < modelNameOne ? "A" : "B"
+
     stmts.push(`ALTER TABLE ${tableNameOne} ADD COLUMN "${foreignName}" CHARACTER VARYING(25);`)
     stmts.push(
       `UPDATE ${tableNameOne} SET "${foreignName}" = ${joinTableName}."${foreignNameLetter}" FROM ${joinTableName} WHERE ${joinTableName}."${columnNameOneIDLetter}" = ${tableNameOne}."${columnNameOneID}";`
@@ -277,6 +278,7 @@ export class Postgres implements Translator {
     const notNull = op.p1FieldOne.optional() ? "" : "NOT NULL"
     const columnNameOneIDLetter = modelNameOther > modelNameOne ? "A" : "B"
     const foreignNameLetter = modelNameOther < modelNameOne ? "A" : "B"
+
     stmts.push(`ALTER TABLE ${tableNameOne} ADD COLUMN "${foreignName}" CHARACTER VARYING(25) unique;`)
     stmts.push(
       `UPDATE ${tableNameOne} SET "${foreignName}" = ${joinTableName}."${foreignNameLetter}" FROM ${joinTableName} WHERE ${joinTableName}."${columnNameOneIDLetter}" = ${tableNameOne}."${columnNameOneID}";`
@@ -551,12 +553,15 @@ export class MySQL5 implements Translator {
     const notNull = op.p1FieldOne.optional() ? "" : "NOT NULL"
     const columnNameOneIDLetter = modelNameOther > modelNameOne ? "A" : "B"
     const foreignNameLetter = modelNameOther < modelNameOne ? "A" : "B"
+
     stmts.push(`ALTER TABLE ${tableNameOne} ADD COLUMN ${foreignName} char(30) CHARACTER SET utf8 unique;`)
     stmts.push(
       `UPDATE ${tableNameOne}, ${joinTableName} SET ${tableNameOne}.${foreignName} = ${joinTableName}.${foreignNameLetter} where ${joinTableName}.${columnNameOneIDLetter} = ${tableNameOne}.${columnNameOneID};`
     )
     if (notNull) {
-      ;`ALTER TABLE ${tableNameOne} CHANGE ${foreignName} ${foreignName} char(30) CHARACTER SET utf8 ${notNull};`
+      stmts.push(
+        `ALTER TABLE ${tableNameOne} CHANGE ${foreignName} ${foreignName} char(30) CHARACTER SET utf8 ${notNull};`
+      )
     }
     stmts.push(
       `ALTER TABLE ${tableNameOne} ADD FOREIGN KEY (${foreignName}) REFERENCES ${tableNameOther}(${columnNameOther});`


### PR DESCRIPTION
Was this intentionally disabled @matthewmueller or a mistake?