### PR TITLE
Show parse error location (row:col) on prisma2

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -138,6 +138,7 @@ async function main(argv: string[]): Promise<void> {
   try {
     prisma2 = new p2.Schema(await readFile(schemaPrisma, "utf8"))
   } catch (err) {
+    const location = err.location ? `${err.location.start.line}:${err.location.start.column} to ${err.location.end.line}:${err.location.end.column}` : ''
     return fatal(
       redent(`
       Error parsing the Prisma 2+ file.
@@ -149,6 +150,10 @@ async function main(argv: string[]): Promise<void> {
       Stack Trace:
 
         ${redent(err.stack || err.message, 4).trim()}
+      
+      Location (line:column):
+
+        ${location}
       `)
     )
   }


### PR DESCRIPTION
When there is an error parsing the prisma2 file (because of prismafile drifting https://www.npmjs.com/package/prismafile), the error shown is something like this
```
Stack Trace:

  SyntaxError: Expected "(", ")", ",", or [_A-Za-z0-9] but ":" found.
  at peg$buildStructuredError (/app/node_modules/prismafile/dist/print.js:640:12)
  at Object.peg$parse [as parse] (/app/node_modules/prismafile/dist/print.js:3057:11)
  at Object.parse (/app/node_modules/prismafile/dist/print.js:3073:17)
  at new Schema (/app/node_modules/prisma-upgrade/dist/index2.js:18:25)
  at main (/app/node_modules/prisma-upgrade/dist/cli/index.js:185:15)
```

This code adds location information to the stack trace, line and column where the parse error occurred on prisma 2 schema file, like this
```
Stack Trace:

  SyntaxError: Expected "(", ")", ",", or [_A-Za-z0-9] but ":" found.
  at peg$buildStructuredError (/app/node_modules/prismafile/dist/print.js:640:12)
  at Object.peg$parse [as parse] (/app/node_modules/prismafile/dist/print.js:3057:11)
  at Object.parse (/app/node_modules/prismafile/dist/print.js:3073:17)
  at new Schema (/app/node_modules/prisma-upgrade/dist/index2.js:18:25)
  at main (/app/node_modules/prisma-upgrade/dist/cli/index.js:185:15)

Location:

  653:24 to 653:25
```

Now it's easier to know why the parsing failed.